### PR TITLE
Remove mongodb-image variable from mongo.yaml

### DIFF
--- a/mongodb/mongo.yaml
+++ b/mongodb/mongo.yaml
@@ -53,9 +53,6 @@ mongodb:
       paths:
         - <- `${monk-volume-path}/mongodb:/data/db`
   variables:
-    mongodb-image:
-      value: latest
-      type: string
     mongo-init-username:
       env: MONGO_INITDB_ROOT_USERNAME
       value: mongo
@@ -83,7 +80,3 @@ mongodb-noauth:
     mongodb:
       paths:
         - <- `${monk-volume-path}/mongodb:/data/db`
-  variables:
-    mongodb-image:
-      value: latest
-      type: string


### PR DESCRIPTION
Removed `mongodb-image` variable from configuration.

Base template already has `mongo-image` var used in container:
```
    mongo-image:
      value: latest
      type: string
```