### PR TITLE
Modernize volume mounts: paths -> mounted-volumes

### DIFF
--- a/mongodb/mongo.yaml
+++ b/mongodb/mongo.yaml
@@ -56,8 +56,12 @@ mongodb:
       protocol: tcp
   containers:
     mongodb:
-      paths:
-        - <- `${monk-volume-path}/mongodb:/data/db`
+      mounted-volumes:
+        mongodb-data:
+          path: /data/db
+  volumes:
+    mongodb-data:
+      kind: local
   variables:
     mongo-init-username:
       env: MONGO_INITDB_ROOT_USERNAME
@@ -84,5 +88,9 @@ mongodb-noauth:
       protocol: tcp
   containers:
     mongodb:
-      paths:
-        - <- `${monk-volume-path}/mongodb:/data/db`
+      mounted-volumes:
+        mongodb-data:
+          path: /data/db
+  volumes:
+    mongodb-data:
+      kind: local


### PR DESCRIPTION
Migrates the base runnable's legacy container `paths:`/`${monk-volume-path}` bind to runnable-level `volumes:` (`kind: local`) + container `mounted-volumes:`. This lets inheriting runnables get modern per-instance volumes without a duplicate-mount. Mount target unchanged; analyzer-clean.
